### PR TITLE
Fix the height of the preview area in Firefox.

### DIFF
--- a/public/stylesheets/programmer.css
+++ b/public/stylesheets/programmer.css
@@ -181,7 +181,7 @@ body {
 
 #viewercontainer {
   width: 100%;
-  height: auto;
+  height: 100%;
   overflow: visible;
   margin-top: 5px;
 }


### PR DESCRIPTION
It was working on all browsers but Firefox.
See https://stackoverflow.com/questions/13056968/iframe-height-attribute-not-working-with-firefox