### PR TITLE
Set the cursor on the first line when reloading the code in the editor

### DIFF
--- a/public/programmerjs/codeinitialization.js
+++ b/public/programmerjs/codeinitialization.js
@@ -40,7 +40,7 @@ Paysage.programmerInit = function () {
     }
 
     Paysage.setCode = function(code) {
-      editor.setValue(code);
+      editor.setValue(code, -1);
     }
   });
 }


### PR DESCRIPTION
This is to avoid the "select all" by default when loading a new code in the editor