### PR TITLE
Patch for transparent background

### DIFF
--- a/public/examples/horizon.pde
+++ b/public/examples/horizon.pde
@@ -73,6 +73,5 @@ void sunmoon(float course) {
 }
 
 void sky(color c) {
-  fill(c);
-  rect(0, 0, width, height);
+  background(c, 240);
 }


### PR DESCRIPTION
Any call to background(), without arguments, will set a transparent background. This forces default background to transparent. 

First, commit processing.js in version 1.6.6 to the depot and then commit the patch. This PR should not been squash to keep track of the patch. 