### PR TITLE
Fix #72 : long code list in programmer view was screwing up the layout

### DIFF
--- a/public/stylesheets/programmer.css
+++ b/public/stylesheets/programmer.css
@@ -35,7 +35,6 @@ body {
 }
 
 .programmertop {
-  display: table-row;
   height: 50px;
 }
 
@@ -51,8 +50,11 @@ body {
   height: 100%;
 }
 
-.codewrapper {
+.programmer-part .programmer-row {
   display: table-row;
+}
+
+.codewrapper {
   height: 100%;
 }
 
@@ -71,6 +73,7 @@ body {
 }
 
 .programmercontrols {
+  display: table-cell;
   height: 8em;
 }
 
@@ -121,7 +124,6 @@ body {
 }
 
 .examples {
-  display: table-row;
   height: 0;
 }
 

--- a/public/stylesheets/programmer.css
+++ b/public/stylesheets/programmer.css
@@ -71,7 +71,6 @@ body {
 }
 
 .programmercontrols {
-  display: table-row;
   height: 8em;
 }
 

--- a/views/programmer.hbs
+++ b/views/programmer.hbs
@@ -13,22 +13,24 @@
 </head>
 <body>
 <div class="programmer-part">
-  <div class="programmertop">
+  <div class="programmertop programmer-row">
     <input type="hidden" id="playgroundid" value="{{playgroundid}}">
     <input type="hidden" id="clientType" value="programmer">
     <input type="text" id="codeid"></input>
   </div>
-  <div class="codewrapper">
+  <div class="codewrapper programmer-row">
     <div id="code" rows="20" cols="30"></div>
   </div>
-  <div class="programmercontrols">
-    <div class="controls">
-      <button id="go-live">go live!</button>
-      <a target="_blank" href="{{reference_url}}" id="openreference">reference ➚</a>
+  <div class="programmer-row">
+    <div class="programmercontrols">
+      <div class="controls">
+        <button id="go-live">go live!</button>
+        <a target="_blank" href="{{reference_url}}" id="openreference">reference ➚</a>
+      </div>
+      <ul id="objects"></ul>
     </div>
-    <ul id="objects"></ul>
   </div>
-  <div class="examples">
+  <div class="examples programmer-row">
     <div class="example empty" data-src="/examples/empty.pde"></div>
     <div class="example number-32" data-src="/examples/number32.pde"></div>
     <div class="example eye" data-src="/examples/eye.pde"></div>


### PR DESCRIPTION
I tested this fix on firefox and chrome and it seems to fix #72. I can't check it for IE11 could someone check that ?

According to the specification:
> In CSS 2.1, the effect of 'min-height' and 'max-height' on tables, inline tables, table cells, table rows, and row groups is undefined.

Apparently we do not need  a display:table-row in this div (is it because of the fix height ?).