### PR TITLE
Fix #73 : Catch codeObject rendering failure at playground full update

### DIFF
--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -34,11 +34,7 @@ io.on('code update', function (data) {
 
 io.on('playground full update', function (data) {
   Object.keys(data).forEach(function (codeObjectId) {
-    try {
       updateObject(codeObjectId, data[codeObjectId].code);
-    } catch (e) {
-      console.error('Error in code object ' + codeObjectId + '. Code not rendered. ' + e);
-    }
   });
 });
 
@@ -89,12 +85,16 @@ function createLayer (targetCanvas, code) {
   // The compilation step is split from the creation of the
   // Processing object so that we can hook the onLoad event
   // to set width and height correctly before setup() runs.
+  try {
   var sketch = window.Processing.compile(code);
   sketch.onLoad = resize;
   var newLayer = new window.Processing(targetCanvas, sketch);
   setDefaultBackgroundToTransparent(newLayer);
   patchBackgroundFunctionToBeTransparentByDefault(newLayer);
   return newLayer;
+  } catch (e) {
+      console.error('Error in code object ' + targetCanvas + '. Code not rendered. ' + e);
+    }
 }
 
 var resizeTimeout;

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -34,7 +34,11 @@ io.on('code update', function (data) {
 
 io.on('playground full update', function (data) {
   Object.keys(data).forEach(function (codeObjectId) {
-    updateObject(codeObjectId, data[codeObjectId].code);
+    try {
+      updateObject(codeObjectId, data[codeObjectId].code);
+    } catch (e) {
+      console.error('Error in code object ' + codeObjectId + '. Code not rendered. ' + e);
+    }
   });
 });
 

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -34,7 +34,7 @@ io.on('code update', function (data) {
 
 io.on('playground full update', function (data) {
   Object.keys(data).forEach(function (codeObjectId) {
-      updateObject(codeObjectId, data[codeObjectId].code);
+    updateObject(codeObjectId, data[codeObjectId].code);
   });
 });
 
@@ -86,15 +86,15 @@ function createLayer (targetCanvas, code) {
   // Processing object so that we can hook the onLoad event
   // to set width and height correctly before setup() runs.
   try {
-  var sketch = window.Processing.compile(code);
-  sketch.onLoad = resize;
-  var newLayer = new window.Processing(targetCanvas, sketch);
-  setDefaultBackgroundToTransparent(newLayer);
-  patchBackgroundFunctionToBeTransparentByDefault(newLayer);
-  return newLayer;
+    var sketch = window.Processing.compile(code);
+    sketch.onLoad = resize;
+    var newLayer = new window.Processing(targetCanvas, sketch);
+    setDefaultBackgroundToTransparent(newLayer);
+    patchBackgroundFunctionToBeTransparentByDefault(newLayer);
+    return newLayer;
   } catch (e) {
-      console.error('Error in code object ' + targetCanvas.getAttribute('id') + '. Code not rendered. ' + e);
-    }
+    console.error('Error in code object ' + targetCanvas.getAttribute('id') + '. Code not rendered. ' + e);
+  }
 }
 
 var resizeTimeout;

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -65,36 +65,36 @@ function patchBackgroundFunctionToBeTransparentByDefault (layer) {
 }
 
 var updateObject = function (id, code) {
-  if (!canvas[id]) {
-    canvas[id] = document.createElement('canvas');
-    canvas[id].setAttribute('id', id);
+  try {
+    if (!canvas[id]) {
+      canvas[id] = document.createElement('canvas');
+      canvas[id].setAttribute('id', id);
 
-    document.getElementById('container').appendChild(canvas[id]);
-    console.log('canvas created for ' + id);
-  } else {
-    console.log('canvas reused for ' + id);
-    try {
-      layers[id].exit();
-    } catch (e) { }
-    delete layers[id];
+      document.getElementById('container').appendChild(canvas[id]);
+      console.log('canvas created for ' + id);
+    } else {
+      console.log('canvas reused for ' + id);
+      try {
+        layers[id].exit();
+      } catch (e) { }
+      delete layers[id];
+    }
+    layers[id] = createLayer(canvas[id], code);
+  } catch (e) {
+    console.error('Error in code object ' + id + '. Code not rendered. ' + e);
   }
-  layers[id] = createLayer(canvas[id], code);
 };
 
 function createLayer (targetCanvas, code) {
   // The compilation step is split from the creation of the
   // Processing object so that we can hook the onLoad event
   // to set width and height correctly before setup() runs.
-  try {
-    var sketch = window.Processing.compile(code);
-    sketch.onLoad = resize;
-    var newLayer = new window.Processing(targetCanvas, sketch);
-    setDefaultBackgroundToTransparent(newLayer);
-    patchBackgroundFunctionToBeTransparentByDefault(newLayer);
-    return newLayer;
-  } catch (e) {
-    console.error('Error in code object ' + targetCanvas.getAttribute('id') + '. Code not rendered. ' + e);
-  }
+  var sketch = window.Processing.compile(code);
+  sketch.onLoad = resize;
+  var newLayer = new window.Processing(targetCanvas, sketch);
+  setDefaultBackgroundToTransparent(newLayer);
+  patchBackgroundFunctionToBeTransparentByDefault(newLayer);
+  return newLayer;
 }
 
 var resizeTimeout;

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -93,7 +93,7 @@ function createLayer (targetCanvas, code) {
   patchBackgroundFunctionToBeTransparentByDefault(newLayer);
   return newLayer;
   } catch (e) {
-      console.error('Error in code object ' + targetCanvas + '. Code not rendered. ' + e);
+      console.error('Error in code object ' + targetCanvas.getAttribute('id') + '. Code not rendered. ' + e);
     }
 }
 

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -39,9 +39,7 @@ io.on('playground full update', function (data) {
 });
 
 var resize = function (layer) {
-  if (layer){
   layer.size(window.innerWidth, window.innerHeight);
-  }
 };
 
 function setDefaultBackgroundToTransparent (layer) {

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -39,7 +39,9 @@ io.on('playground full update', function (data) {
 });
 
 var resize = function (layer) {
+  if (layer){
   layer.size(window.innerWidth, window.innerHeight);
+  }
 };
 
 function setDefaultBackgroundToTransparent (layer) {


### PR DESCRIPTION
If the error is not cached other code object will not be rendered during full playground update.

This fix issue #73

By the way I added a error log making it easier for the teacher to identify the falty code object.