### PR TITLE
Preserve object creation order in rendering

### DIFF
--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -32,8 +32,8 @@
 
   io.on('playground full update', function (data) {
     clearLayersAndCanvas();
-    Object.keys(data).forEach(function (codeObjectId) {
-      updateObject(codeObjectId, data[codeObjectId].code);
+    data.forEach(function (codeObject) {
+      updateObject(codeObject.codeObjectId, codeObject.code);
     });
   });
 

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -19,7 +19,8 @@ describe('A playground', function () {
   it("can list its codeObject's ids", function () {
     playground.getOrCreateCodeObject('bob');
     playground.getOrCreateCodeObject('jack');
-    expect(playground.population()).to.have.members(['bob', 'jack']);
+    playground.getOrCreateCodeObject('0');
+    expect(playground.population()).to.deep.equal(['bob', 'jack', '0']);
   });
 
   it('can tell if it is empty', function () {
@@ -54,19 +55,19 @@ describe('A playground', function () {
     playground.getOrCreateCodeObject('bob');
     playground.deleteCodeObject('bob');
 
-    expect(playground.codeObjects).to.deep.equal({});
+    expect(playground.population()).to.deep.equal([]);
     expect(playground.contains('bob')).to.be.false;
   });
 
   it("'s data contains its code objects", function () {
     var bob = playground.getOrCreateCodeObject('bob');
     bob.setData({code: 'hello()'});
-    expect(playground.getData()).to.deep.equal({
-      bob: {
+    expect(playground.getData()).to.deep.equal([
+      {
         codeObjectId: 'bob',
         code: 'hello()'
       }
-    });
+    ]);
   });
 
   it('can return data for an existing code object', function () {

--- a/test/integration.js
+++ b/test/integration.js
@@ -41,7 +41,7 @@ describe('The Paysage server', function () {
 
       renderer.on('connect', function () {
         renderer.once('playground full update', function (data) {
-          expect(data).to.deep.equal({});
+          expect(data).to.deep.equal([]);
           doneWhenCalledTwice();
         });
       });


### PR DESCRIPTION
Fixes #85. An ES Map (insertion-order preserving) is used server-side,
and the objects are now sent to the renderer as an array instead of a
(non-order-preserving) JSON object.