### PR TITLE
Focus in editor after Go Live and Load Example

### DIFF
--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -45,12 +45,21 @@ var Paysage = window.Paysage || {};
         exec: Paysage.goLive
       });
       editor.$blockScrolling = Infinity; // to avoid the warning about deprecated scrolling https://github.com/ajaxorg/ace/issues/2499
+
+      editor.on('change', focusBackToEditor); // ensure focus when new code is loaded
+
+      document.getElementById('go-live').addEventListener('click', focusBackToEditor);
+
+      function focusBackToEditor (event) {
+        editor.focus();
+      }
+
       Paysage.getCode = function () {
         return editor.getValue();
       };
 
       Paysage.setCode = function (code) {
-        editor.setValue(code, -1);
+        editor.setValue(code, -1); // -1 move the cursor to the top of the editor
       };
     });
   };

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -5,7 +5,7 @@ var Paysage = window.Paysage || {};
   'use strict';
 
   // Requires a sourcebuilder script defining Paysage.getCompleteCodeObject()
-  // Requires a codeinitialization script defining Paysage.setCodeId() and Paysage.setCode()
+  // Requires a editingcode script defining Paysage.setCodeId() and Paysage.setCode()
 
   Paysage.requestCode = function (codeObjectId) {
     var data = {

--- a/public/programmerjs/sourcebuilder.js
+++ b/public/programmerjs/sourcebuilder.js
@@ -6,7 +6,7 @@
 
 // the sourcebuilder only concern is to build and give a code object ready to be sent to the paysage server
 
- // Requires a codeinitialization script defining Paysage.getCode()
+ // Requires a editingcode script defining Paysage.getCode()
 
 var Paysage = window.Paysage || {};
 

--- a/testem.yml
+++ b/testem.yml
@@ -5,6 +5,6 @@ src_files:
 - "public/bower_components/eventEmitter/EventEmitter.js"
 - "public/bower_components/Processing.js/processing.js"
 - "public/bower_components/jasmine-jquery/lib/jasmine-jquery.js"
-- "public/programmerjs/codeinitialization.js"
 - "public/paysagerenderer.js"
+- "public/programmerjs/editingcode.js"
 - "spec/public/**/*.js"

--- a/views/programmer.hbs
+++ b/views/programmer.hbs
@@ -58,7 +58,7 @@
 </div>
 <script src="/programmerjs/sourcebuilder.js"></script>
 <script src="/programmerjs/receptiontransmission.js"></script>
-<script src="/programmerjs/codeinitialization.js"></script>
+<script src="/programmerjs/editingcode.js"></script>
 <script src="/programmerjs/previewmanagement.js"></script>
 <script>
 $(Paysage.programmerInit);


### PR DESCRIPTION
We focus back to the editor in the cases of clicking [Go Live!] and clicking an example – allowing the users to resume their programming flow without moving the mouse/finger to the editor space and clicking/taping. 
Segregated in a new ui management JS file.