### PR TITLE
Add a shortcut for the goLive button from the editor

### DIFF
--- a/public/programmerjs/codeinitialization.js
+++ b/public/programmerjs/codeinitialization.js
@@ -39,6 +39,11 @@ var Paysage = window.Paysage || {};
       var editor = window.ace.edit(this);
       editor.getSession().setMode('ace/mode/java');
       editor.setShowPrintMargin(false);
+      editor.commands.addCommand({
+        name: 'go-liveShortcuts',
+        bindKey: {win: 'Ctrl-Alt-g', mac: 'Command-Alt-g'},
+        exec: Paysage.goLive
+      });
       editor.$blockScrolling = Infinity; // to avoid the warning about deprecated scrolling https://github.com/ajaxorg/ace/issues/2499
       Paysage.getCode = function () {
         return editor.getValue();

--- a/public/programmerjs/codeinitialization.js
+++ b/public/programmerjs/codeinitialization.js
@@ -41,7 +41,7 @@ var Paysage = window.Paysage || {};
       editor.setShowPrintMargin(false);
       editor.commands.addCommand({
         name: 'go-liveShortcuts',
-        bindKey: {win: 'Ctrl-Alt-g', mac: 'Command-Alt-g'},
+        bindKey: {win: 'Ctrl-Enter', mac: 'Command-Enter'},
         exec: Paysage.goLive
       });
       editor.$blockScrolling = Infinity; // to avoid the warning about deprecated scrolling https://github.com/ajaxorg/ace/issues/2499

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -22,13 +22,14 @@ var Paysage = window.Paysage || {};
     client: clientType
   }}).connect();
 
-  document.getElementById('go-live').addEventListener('click', function () {
+  Paysage.goLive = function () {
     function emitData (data) {
       console.log(data);
       io.emit('code update', data);
     }
     Paysage.getCompleteCodeObject(emitData);
-  });
+  };
+  document.getElementById('go-live').addEventListener('click', Paysage.goLive);
 
   function deleteCode (codeObjectId) {
     var data = {


### PR DESCRIPTION
It uses ctrl-alt-g on windows or linux (if I understand)
and cmd-alt-g on mac.

I've been testing on Mac and I would be glad if someone could validate on windows and linux.