### PR TITLE
In switchframe, wait for the end of the hide animation before detaching

### DIFF
--- a/public/programmerjs/previewmanagement.js
+++ b/public/programmerjs/previewmanagement.js
@@ -8,14 +8,15 @@
   function switchframe (event) {
     event.preventDefault();
     if (frozenpreview) {
-      $('#viewercontainer').show(150);
       frozenpreview.appendTo('#viewercontainer');
       frozenpreview = null;
+      $('#viewercontainer').show();
       $('#previewisoff').hide();
       $('#previewison').show();
     } else {
-      frozenpreview = $('#viewerframe').detach();
-      $('#viewercontainer').hide(150);
+      $('#viewercontainer').hide(1, function () {
+        frozenpreview = $('#viewerframe').detach();
+      });
       $('#previewison').hide();
       $('#previewisoff').show();
     }


### PR DESCRIPTION
In switchframe, wait for the end of the hide animation before detaching the preview frame

- This has a side effect of fixing the problem with the switch animation in firefox.
- I also removed the delay for the show() to speed up the process.