### PR TITLE
Set editor tabsize to 2 and reformat examples

### DIFF
--- a/public/examples/eye.pde
+++ b/public/examples/eye.pde
@@ -1,17 +1,17 @@
 void draw() {
   background(0,0);
 
-  translate(200 + 100 * Math.cos(millis()/800), 200 + 100 * Math.sin(millis() / 750))
+  translate(200 + 100 * Math.cos(millis()/800), 200 + 100 * Math.sin(millis() / 750));
 
-  fill(200, 80, 80)
-  ellipse(0,0,120,120)
+  fill(200, 80, 80);
+  ellipse(0,0,120,120);
 
-  fill(60, 60, 123)
-  ellipse(0,0,100,100)
+  fill(60, 60, 123);
+  ellipse(0,0,100,100);
 
-  fill(130, 130, 140)
-  ellipse(0,0,70,70)
+  fill(130, 130, 140);
+  ellipse(0,0,70,70);
 
-  fill(0, 220, 120)
-  ellipse(0,0,40,40)
+  fill(0, 220, 120);
+  ellipse(0,0,40,40);
 }

--- a/public/examples/serpent.pde
+++ b/public/examples/serpent.pde
@@ -1,81 +1,81 @@
 class Serpent {
-    PVector loc;
-    PVector vel;
-    ArrayList anneaux = new ArrayList();
-    color maCouleur;
+  PVector loc;
+  PVector vel;
+  ArrayList anneaux = new ArrayList();
+  color maCouleur;
 
-    Serpent() {
-        loc = new PVector(random(width), random(height));
-        vel = new PVector(5, 5);
+  Serpent() {
+    loc = new PVector(random(width), random(height));
+    vel = new PVector(5, 5);
+  }
+
+  void avance(float vitesseMax, float taille) {
+    PVector acc = new PVector(random(-1, 1), random(-1, 1));
+    acc.normalize();
+
+    vel.add(acc);
+    vel.limit(vitesseMax);
+
+    loc.add(vel);
+
+    anneaux.add(new PVector(loc.x, loc.y));
+    if (anneaux.size() > taille) {
+      anneaux.remove(0);
     }
+  }
 
-    void avance(float vitesseMax, float taille) {
-        PVector acc = new PVector(random(-1, 1), random(-1, 1));
-        acc.normalize();
+  void dessineToi() {
 
-        vel.add(acc);
-        vel.limit(vitesseMax);
+    beginShape();
 
-        loc.add(vel);
+    stroke(maCouleur);
+    fill(0, 0, 0, 0); // en changeant le remplissage, des choses amusantes peuvent se dessiner
 
-        anneaux.add(new PVector(loc.x, loc.y));
-        if (anneaux.size() > taille) {
-            anneaux.remove(0);
-        }
+    for (int i = 0; i <= anneaux.size()-1; i++) {
+      PVector a = (PVector) anneaux.get(i);
+      curveVertex(a.x, a.y);
     }
+    endShape();
+  }
 
-    void dessineToi() {
-
-        beginShape();
-
-        stroke(maCouleur);
-        fill(0, 0, 0, 0); // en changeant le remplissage, des choses amusantes peuvent se dessiner
-
-        for (int i = 0; i <= anneaux.size()-1; i++) {
-            PVector a = (PVector) anneaux.get(i);
-            curveVertex(a.x, a.y);
-        }
-        endShape();
+  void rebondis() {
+    if ((loc.x > width) || (loc.x < 0)) {
+      if (loc.x > width) {
+        loc.x = width;
+      } else if (loc.x < 0) {
+        loc.x = 0;
+      }
+      vel.x = vel.x * -1;
     }
-
-    void rebondis() {
-        if ((loc.x > width) || (loc.x < 0)) {
-            if (loc.x > width) {
-                loc.x = width;
-            } else if (loc.x < 0) {
-                loc.x = 0;
-            }
-            vel.x = vel.x * -1;
-        }
-        if ((loc.y > height) || (loc.y < 0)) {
-            if (loc.y > height) {
-                loc.y = height;
-            } else if (loc.y < 0) {
-                loc.y = 0;
-            }
-            vel.y = vel.y * -1;
-        }
+    if ((loc.y > height) || (loc.y < 0)) {
+      if (loc.y > height) {
+        loc.y = height;
+      } else if (loc.y < 0) {
+        loc.y = 0;
+      }
+      vel.y = vel.y * -1;
     }
+  }
 
-    void changeTaCouleur(float rouge, float vert, float bleu) {
-      this.maCouleur = color(rouge, vert, bleu);
-    }
+  void changeTaCouleur(float rouge, float vert, float bleu) {
+    this.maCouleur = color(rouge, vert, bleu);
+  }
 }
 
 Serpent monSerpent;
 
 void setup() {
-    stroke(0);
-    strokeWeight(4);
+  stroke(0);
+  strokeWeight(4);
 
-    monSerpent = new Serpent();
+  monSerpent = new Serpent();
 }
 
 void draw() {
-    background(255, 0); // essayez de l'enlever pour garder la trace du chemin du serpent
+  background(255, 0); // essayez de l'enlever pour garder la trace du chemin du serpent
 
-    monSerpent.changeTaCouleur(0, 0, 0);
-    monSerpent.avance(10, 10);
-    monSerpent.rebondis();
-    monSerpent.dessineToi();
+  monSerpent.changeTaCouleur(0, 0, 0);
+  monSerpent.avance(10, 10);
+  monSerpent.rebondis();
+  monSerpent.dessineToi();
 }

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -39,6 +39,7 @@ var Paysage = window.Paysage || {};
       var editor = window.ace.edit(this);
       editor.getSession().setMode('ace/mode/java');
       editor.setShowPrintMargin(false);
+      editor.setOption('tabSize', 2);
       editor.commands.addCommand({
         name: 'go-liveShortcuts',
         bindKey: {win: 'Ctrl-Enter', mac: 'Command-Enter'},


### PR DESCRIPTION
I configure the ace editor for a 2 characters tabsize to correspond to the what was used in most examples. 

I reformated the examples that where using a tabsize of 4, except for the creature example that is the object of an other pull request