### PR TITLE
Create the "name" property and add the rename behaviour

### DIFF
--- a/CodeObject.js
+++ b/CodeObject.js
@@ -4,11 +4,20 @@ function CodeObject (id, updated) {
   this._updated = updated || function () {};
   this.id = id;
   this._data = Object.create(null);
+  this._data.name = id;
   this._data.code = '';
 }
 
-CodeObject.prototype.setId = function (newId) {
-  this.id = newId;
+CodeObject.prototype.setName = function (newName) {
+  this._data.name = newName;
+};
+
+CodeObject.prototype.getName = function () {
+  return this._data.name;
+};
+
+CodeObject.prototype.getId = function () {
+  return this.id;
 };
 
 CodeObject.prototype.setData = function (data) {

--- a/CodeObject.js
+++ b/CodeObject.js
@@ -31,12 +31,13 @@ CodeObject.prototype.setData = function (data) {
   this._updated(this);
 };
 
-CodeObject.prototype.getData = function () {
+CodeObject.prototype.getData = function (propertyName) {
   var data = { codeObjectId: this.id };
-  var that = this;
-  Object.keys(this._data).forEach(function (key) {
-    data[key] = that._data[key];
-  });
+  for (var key of Object.keys(this._data)) {
+    if (!propertyName || propertyName === key) {
+      data[key] = this._data[key];
+    }
+  }
   return data;
 };
 

--- a/CodeObject.js
+++ b/CodeObject.js
@@ -7,6 +7,10 @@ function CodeObject (id, updated) {
   this._data.code = '';
 }
 
+CodeObject.prototype.setId = function (newId) {
+  this.id = newId;
+};
+
 CodeObject.prototype.setData = function (data) {
   if (data.codeObjectId && data.codeObjectId !== this.id) {
     throw new Error('Attempt to change id');

--- a/Playground.js
+++ b/Playground.js
@@ -31,21 +31,19 @@ Playground.prototype.deleteCodeObject = function (codeObjectId) {
   return codeObject;
 };
 
-Playground.prototype.renameCodeObject = function (oldCodeObjectId, newCodeObjectId) {
-  var newMap = new Map();
-  for (var [k, co] of this._codeObjects) {
-    var newKey = k;
-    if (k === oldCodeObjectId) {
-      newKey = newCodeObjectId;
-      co.setId(newCodeObjectId);
-    }
-    newMap.set(newKey, co);
+Playground.prototype.renameCodeObject = function (codeObjectId, newName) {
+  if (this._codeObjects.has(codeObjectId)) {
+    this._codeObjects.get(codeObjectId).setName(newName);
   }
-  this._codeObjects = newMap;
 };
 
 Playground.prototype.population = function () {
-  return Array.from(this._codeObjects.keys());
+  return Array.from(this._codeObjects.values()).map(function (co) {
+    return {
+      id: co.getId(),
+      name: co.getName()
+    };
+  });
 };
 
 Playground.prototype.isEmpty = function () {

--- a/Playground.js
+++ b/Playground.js
@@ -31,6 +31,13 @@ Playground.prototype.deleteCodeObject = function (codeObjectId) {
   return codeObject;
 };
 
+Playground.prototype.renameCodeObject = function (oldCodeObjectId, newCodeObjectId) {
+  const codeObject = this._codeObjects.get(oldCodeObjectId);
+  this._codeObjects.delete(oldCodeObjectId);
+  this._codeObjects.set(newCodeObjectId, codeObject);
+  this.emit('codeObjectUpdated', codeObject);
+};
+
 Playground.prototype.population = function () {
   return Array.from(this._codeObjects.keys());
 };

--- a/Playground.js
+++ b/Playground.js
@@ -32,10 +32,16 @@ Playground.prototype.deleteCodeObject = function (codeObjectId) {
 };
 
 Playground.prototype.renameCodeObject = function (oldCodeObjectId, newCodeObjectId) {
-  const codeObject = this._codeObjects.get(oldCodeObjectId);
-  this._codeObjects.delete(oldCodeObjectId);
-  this._codeObjects.set(newCodeObjectId, codeObject);
-  this.emit('codeObjectUpdated', codeObject);
+  var newMap = new Map();
+  for (var [k, co] of this._codeObjects) {
+    var newKey = k;
+    if (k === oldCodeObjectId) {
+      newKey = newCodeObjectId;
+      co.setId(newCodeObjectId);
+    }
+    newMap.set(newKey, co);
+  }
+  this._codeObjects = newMap;
 };
 
 Playground.prototype.population = function () {

--- a/Playground.js
+++ b/Playground.js
@@ -37,15 +37,6 @@ Playground.prototype.renameCodeObject = function (codeObjectId, newName) {
   }
 };
 
-Playground.prototype.population = function () {
-  return Array.from(this._codeObjects.values()).map(function (co) {
-    return {
-      id: co.getId(),
-      name: co.getName()
-    };
-  });
-};
-
 Playground.prototype.isEmpty = function () {
   return this._codeObjects.size === 0;
 };
@@ -54,9 +45,9 @@ Playground.prototype.contains = function (id) {
   return this._codeObjects.has(id);
 };
 
-Playground.prototype.getData = function () {
+Playground.prototype.getData = function (property) {
   return Array.from(this._codeObjects.values())
-    .map((codeObject) => codeObject.getData());
+    .map((codeObject) => codeObject.getData(property));
 };
 
 Playground.prototype.getDataFor = function (codeObjectId) {

--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ module.exports = function (maybeWorld) {
     }
 
     function sendListOfAllObjects () {
-      socket.emit('objects list', {objectIdsAndNames: playground.population()});
+      socket.emit('objects list', {data: playground.getData('name')});
     }
 
     function programmerUp () {

--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ module.exports = function (maybeWorld) {
     }
 
     function sendListOfAllObjects () {
-      socket.emit('objects list', {objectIds: playground.population()});
+      socket.emit('objects list', {objectIdsAndNames: playground.population()});
     }
 
     function programmerUp () {
@@ -97,10 +97,9 @@ module.exports = function (maybeWorld) {
     });
 
     socket.on('code rename', function (data) {
-      debug('renaming ' + data.oldCodeObjectId + ' to ' + data.newCodeObjectId + ' from playground ' + playground.id);
+      debug('renaming ' + data.codeObjectId + ' to ' + data.newName + ' from playground ' + playground.id);
 
-      playground.renameCodeObject(data.oldCodeObjectId, data.newCodeObjectId);
-      socket.emit('code rename', data);
+      playground.renameCodeObject(data.codeObjectId, data.newName);
       sendListOfAllObjects();
     });
 

--- a/app.js
+++ b/app.js
@@ -96,6 +96,14 @@ module.exports = function (maybeWorld) {
       }
     });
 
+    socket.on('code rename', function (data) {
+      debug('renaming ' + data.oldCodeObjectId + ' to ' + data.newCodeObjectId + ' from playground ' + playground.id);
+
+      if (playground.contains(data.codeObjectId)) {
+        playground.renameCodeObject(data.oldCodeObjectId, data.newCodeObjectId);
+      }
+    });
+
     socket.on('request code', function (data) {
       debug(data.codeObjectId + ' for ' + playground.id + ' programmer');
 

--- a/app.js
+++ b/app.js
@@ -64,6 +64,10 @@ module.exports = function (maybeWorld) {
       programmerUp();
     }
 
+    function sendListOfAllObjects () {
+      socket.emit('objects list', {objectIds: playground.population()});
+    }
+
     function programmerUp () {
       debug('a new programmer is up for ' + playground.id);
 
@@ -74,10 +78,6 @@ module.exports = function (maybeWorld) {
       debug('a new renderer is up for ' + playground.id);
 
       socket.emit('playground full update', playground.getData());
-    }
-
-    function sendListOfAllObjects () {
-      socket.emit('objects list', {objectIds: playground.population()});
     }
 
     socket.on('code update', function (data) {
@@ -99,9 +99,9 @@ module.exports = function (maybeWorld) {
     socket.on('code rename', function (data) {
       debug('renaming ' + data.oldCodeObjectId + ' to ' + data.newCodeObjectId + ' from playground ' + playground.id);
 
-      if (playground.contains(data.codeObjectId)) {
-        playground.renameCodeObject(data.oldCodeObjectId, data.newCodeObjectId);
-      }
+      playground.renameCodeObject(data.oldCodeObjectId, data.newCodeObjectId);
+      socket.emit('code rename', data);
+      sendListOfAllObjects();
     });
 
     socket.on('request code', function (data) {

--- a/doc/messages.md
+++ b/doc/messages.md
@@ -48,3 +48,13 @@ programmer     programmer browser          server                 preview/other 
   |                  |<----------------------+----- objects list ---------->|
 ```
 
+# programmer rename a code
+
+```text
+programmer          programmer browser            server                  preview/other clients
+  |--- change input id ---->|                       |                               |
+  |                         |---- code rename ----->|                               |
+  |                         |                       |------ code rename ----------->|
+  |                         |<----------------------+------ objects list ---------->|
+```
+

--- a/doc/messages.md
+++ b/doc/messages.md
@@ -54,7 +54,6 @@ programmer     programmer browser          server                 preview/other 
 programmer          programmer browser            server                  preview/other clients
   |--- change input id ---->|                       |                               |
   |                         |---- code rename ----->|                               |
-  |                         |                       |------ code rename ----------->|
   |                         |<----------------------+------ objects list ---------->|
 ```
 

--- a/e2etests/page_objects/programmer.js
+++ b/e2etests/page_objects/programmer.js
@@ -12,11 +12,18 @@ module.exports = {
     'bottommost-codeObject-trash': '#objects li:last-of-type a:last-of-type'
   },
   commands: [{
-    setCodeId: function (codeid) {
+    setCodeName: function (codeName) {
       this.api.execute(`
-        var codeid = document.querySelector("#codeid");
-        codeid.value = "${codeid}";
-        codeid.dispatchEvent(new Event("input"));
+        var codeNameElement = document.querySelector("#codeName");
+        codeNameElement.value = "${codeName}";
+        codeNameElement.dispatchEvent(new Event("input"));
+      `);
+      return this;
+    },
+    clickExample: function () {
+      this.api.execute(`
+        var example = document.querySelector(".example");
+        example.dispatchEvent(new Event("click"));
       `);
       return this;
     },

--- a/e2etests/tests/test.js
+++ b/e2etests/tests/test.js
@@ -32,7 +32,7 @@ module.exports = {
   'New code object is listed': function (browser) {
     browser.page.programmer()
       .navigate()
-      .setCodeId('jim')
+      .setCodeName('jim')
       .click('@go-live')
       .expect.element('@bottommost-codeObject').text.to.equal('jim');
   },
@@ -40,9 +40,11 @@ module.exports = {
   'A listed code object can be deleted, supposing latest created object on top': function (browser) {
     browser.page.programmer()
       .navigate()
-      .setCodeId('jul')
+      .clickExample()
+      .setCodeName('jul')
       .click('@go-live')
-      .setCodeId('jim')
+      .clickExample()
+      .setCodeName('jim')
       .click('@go-live')
       .click('@bottommost-codeObject-trash')
       .expect.element('@bottommost-codeObject').text.to.equal('jim');

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -26,6 +26,10 @@ var Paysage = window.Paysage || {};
       deleteCanvas(id);
     });
 
+    socket.on('code rename', function (data) {
+
+    });
+
     socket.on('code update', function (data) {
       var id = data.codeObjectId;
       var code = data.code;

--- a/public/paysagerenderer.js
+++ b/public/paysagerenderer.js
@@ -26,10 +26,6 @@ var Paysage = window.Paysage || {};
       deleteCanvas(id);
     });
 
-    socket.on('code rename', function (data) {
-
-    });
-
     socket.on('code update', function (data) {
       var id = data.codeObjectId;
       var code = data.code;

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -11,8 +11,14 @@ var Paysage = window.Paysage || {};
     window.location.hash = codeId;
   };
 
+  Paysage.setCodeName = function (codeName) {
+    $('#codeName').val(codeName);
+  };
+
   Paysage.createCodeId = function () {
-    Paysage.setCodeId(window.chance.word());
+    var codeId = window.chance.word();
+    Paysage.setCodeName(codeId);
+    Paysage.setCodeId(codeId);
   };
 
   Paysage.getCode = function () {
@@ -34,13 +40,9 @@ var Paysage = window.Paysage || {};
 
     setupDragAndDropListeners();
 
-    $('#codeid').on('focus', function (event) {
-      this.oldvalue = this.value;
-    });
-
-    $('#codeid').on('change', function (event) {
-      Paysage.renameCode(event.target.oldvalue, event.target.value);
-      event.target.oldvalue = event.target.value;
+    $('#codeName').on('change', function (event) {
+      Paysage.renameCode(document.getElementById('codeid').value,
+        event.target.value);
     });
 
     // Initialize ACE code editor

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -39,11 +39,8 @@ var Paysage = window.Paysage || {};
     });
 
     $('#codeid').on('change', function (event) {
-      // delete old code
-      Paysage.deleteCode(event.target.oldvalue);
-      // goLive current code
+      Paysage.renameCode(event.target.oldvalue, event.target.value);
       event.target.oldvalue = event.target.value;
-      Paysage.goLive();
     });
 
     // Initialize ACE code editor

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -34,6 +34,18 @@ var Paysage = window.Paysage || {};
 
     setupDragAndDropListeners();
 
+    $('#codeid').on('focus', function (event) {
+      this.oldvalue = this.value;
+    });
+
+    $('#codeid').on('change', function (event) {
+      // delete old code
+      Paysage.deleteCode(event.target.oldvalue);
+      // goLive current code
+      event.target.oldvalue = event.target.value;
+      Paysage.goLive();
+    });
+
     // Initialize ACE code editor
     $('#code').each(function () {
       var editor = window.ace.edit(this);

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -5,7 +5,8 @@ var Paysage = window.Paysage || {};
   'use strict';
 
   // Requires a sourcebuilder script defining Paysage.getCompleteCodeObject()
-  // Requires a editingcode script defining Paysage.setCodeId() and Paysage.setCode()
+  // Requires a editingcode script defining Paysage.setCodeId(),
+  // Paysage.setCodeName() and Paysage.setCode()
 
   Paysage.requestCode = function (codeObjectId) {
     var data = {
@@ -38,28 +39,28 @@ var Paysage = window.Paysage || {};
     io.emit('code delete', data);
   };
 
-  Paysage.renameCode = function (oldCodeObjectId, newCodeObjectId) {
+  Paysage.renameCode = function (codeObjectId, newName) {
     var data = {
-      oldCodeObjectId: oldCodeObjectId,
-      newCodeObjectId: newCodeObjectId
+      codeObjectId: codeObjectId,
+      newName: newName
     };
     io.emit('code rename', data);
   };
 
   io.on('objects list', function (data) {
-    var objectIds = data.objectIds;
+    var objectIdsNames = data.objectIdsAndNames;
     var $objects = $('#objects');
     $objects.empty();
-    $objects.append(objectIds.reverse().map(function (objectId) {
-      var $openLink = $("<a href='#'>").text(objectId);
+    $objects.append(objectIdsNames.reverse().map(function (objectIdName) {
+      var $openLink = $("<a href='#'>").text(objectIdName.name);
       $openLink.click(function (event) {
         event.preventDefault();
-        Paysage.requestCode(objectId);
+        Paysage.requestCode(objectIdName.id);
       });
       var $deleteLink = $('<a class="glyphicon glyphicon-trash" href="#">');
       $deleteLink.click(function (event) {
         event.preventDefault();
-        Paysage.deleteCode(objectId);
+        Paysage.deleteCode(objectIdName.id);
       });
       return $('<li>').append($openLink).append(' - ').append($deleteLink);
     }));
@@ -67,6 +68,7 @@ var Paysage = window.Paysage || {};
 
   io.on('source code', function (data) {
     Paysage.setCodeId(data.codeObjectId);
+    Paysage.setCodeName(data.name ? data.name : data.codeObjectId);
     Paysage.setCode(data.code);
   });
 }());

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -47,20 +47,19 @@ var Paysage = window.Paysage || {};
     io.emit('code rename', data);
   };
 
-  io.on('objects list', function (data) {
-    var objectIdsNames = data.objectIdsAndNames;
+  io.on('objects list', function (population) {
     var $objects = $('#objects');
     $objects.empty();
-    $objects.append(objectIdsNames.reverse().map(function (objectIdName) {
-      var $openLink = $("<a href='#'>").text(objectIdName.name);
+    $objects.append(population.data.reverse().map(function (co) {
+      var $openLink = $("<a href='#'>").text(co.name);
       $openLink.click(function (event) {
         event.preventDefault();
-        Paysage.requestCode(objectIdName.id);
+        Paysage.requestCode(co.codeObjectId);
       });
       var $deleteLink = $('<a class="glyphicon glyphicon-trash" href="#">');
       $deleteLink.click(function (event) {
         event.preventDefault();
-        Paysage.deleteCode(objectIdName.id);
+        Paysage.deleteCode(co.codeObjectId);
       });
       return $('<li>').append($openLink).append(' - ').append($deleteLink);
     }));

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -31,12 +31,12 @@ var Paysage = window.Paysage || {};
   };
   document.getElementById('go-live').addEventListener('click', Paysage.goLive);
 
-  function deleteCode (codeObjectId) {
+  Paysage.deleteCode = function (codeObjectId) {
     var data = {
       codeObjectId: codeObjectId
     };
     io.emit('code delete', data);
-  }
+  };
 
   io.on('objects list', function (data) {
     var objectIds = data.objectIds;
@@ -51,7 +51,7 @@ var Paysage = window.Paysage || {};
       var $deleteLink = $('<a class="glyphicon glyphicon-trash" href="#">');
       $deleteLink.click(function (event) {
         event.preventDefault();
-        deleteCode(objectId);
+        Paysage.deleteCode(objectId);
       });
       return $('<li>').append($openLink).append(' - ').append($deleteLink);
     }));

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -38,6 +38,14 @@ var Paysage = window.Paysage || {};
     io.emit('code delete', data);
   };
 
+  Paysage.renameCode = function (oldCodeObjectId, newCodeObjectId) {
+    var data = {
+      oldCodeObjectId: oldCodeObjectId,
+      newCodeObjectId: newCodeObjectId
+    };
+    io.emit('code rename', data);
+  };
+
   io.on('objects list', function (data) {
     var objectIds = data.objectIds;
     var $objects = $('#objects');

--- a/public/programmerjs/sourcebuilder.js
+++ b/public/programmerjs/sourcebuilder.js
@@ -12,11 +12,13 @@ var Paysage = window.Paysage || {};
 
 Paysage.getCompleteCodeObject = function (callback) {
   var codeObjectId = document.getElementById('codeid').value || document.getElementById('codeid').textContent;
+  var codeObjectName = document.getElementById('codeName').value;
   var mediatype = 'text/processing';
   var code = Paysage.getCode();
 
   var data = {
     codeObjectId: codeObjectId,
+    name: codeObjectName,
     mediatype: mediatype,
     code: code
   };

--- a/public/stylesheets/programmer.css
+++ b/public/stylesheets/programmer.css
@@ -38,7 +38,7 @@ body {
   height: 50px;
 }
 
-#codeid {
+#codeName {
   font-size: 2em;
   width: 10em;
   margin-bottom: 5px;

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -4,6 +4,7 @@ describe('The Paysage programmer', function () {
   beforeEach(function () {
     $(document.body).append('<div id="testcontainer">' +
       '<div><input id="codeid"></div>' +
+      '<div><input id="codeName"></div>' +
       '</div>'
     );
     window.location.hash = '';
@@ -18,20 +19,21 @@ describe('The Paysage programmer', function () {
 
     expect(window.location.hash).not.toBe('');
     expect($('#codeid').val()).toBe(window.location.hash.slice(1));
+    expect($('#codeName').val()).toBe(window.location.hash.slice(1));
   });
 
-  it('rename a code when codeid is changed', function () {
-    var oldCodeId;
-    var newCodeId;
-    Paysage.renameCode = function (oldId, newId) {
-      oldCodeId = oldId;
-      newCodeId = newId;
+  it('rename a code when codeName is changed', function () {
+    var codeId;
+    var newCodeName;
+    Paysage.renameCode = function (_codeId, newName) {
+      codeId = _codeId;
+      newCodeName = newName;
     };
     Paysage.programmerInit();
-    document.getElementById('codeid').oldvalue = 'ancienNom';
-    $('#codeid').val('nouveauNom');
-    $('#codeid').trigger('change');
-    expect(oldCodeId).toBe('ancienNom');
-    expect(newCodeId).toBe('nouveauNom');
+    document.getElementById('codeid').value = 'codeId';
+    $('#codeName').val('nouveauNom');
+    $('#codeName').trigger('change');
+    expect(codeId).toBe('codeId');
+    expect(newCodeName).toBe('nouveauNom');
   });
 });

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -1,13 +1,39 @@
-/* global describe, it, expect */
+/* global describe, beforeEach, afterEach, it, expect */
 /* global $, Paysage */
 describe('The Paysage programmer', function () {
-  it('generates a random creature name on initialization', function () {
+  beforeEach(function () {
+    $(document.body).append('<div id="testcontainer">' +
+      '<div><input id="codeid"></div>' +
+      '</div>'
+    );
     window.location.hash = '';
-    $(document.body).append('<div><input id="codeid"></div>');
+  });
 
+  afterEach(function () {
+    $('#testcontainer').remove();
+  });
+
+  it('generates a random creature name on initialization', function () {
     Paysage.programmerInit();
 
     expect(window.location.hash).not.toBe('');
     expect($('#codeid').val()).toBe(window.location.hash.slice(1));
+  });
+
+  it('rename a code when codeid is changed', function () {
+    var goLiveCall = 0;
+    var oldCodeId;
+    Paysage.deleteCode = function (codeId) {
+      oldCodeId = codeId;
+    };
+    Paysage.goLive = function () {
+      goLiveCall++;
+    };
+    Paysage.programmerInit();
+    document.getElementById('codeid').oldvalue = 'ancienNom';
+    $('#codeid').val('nouveauNom');
+    $('#codeid').trigger('change');
+    expect(oldCodeId).toBe('ancienNom');
+    expect(goLiveCall).toBe(1);
   });
 });

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -21,19 +21,17 @@ describe('The Paysage programmer', function () {
   });
 
   it('rename a code when codeid is changed', function () {
-    var goLiveCall = 0;
     var oldCodeId;
-    Paysage.deleteCode = function (codeId) {
-      oldCodeId = codeId;
-    };
-    Paysage.goLive = function () {
-      goLiveCall++;
+    var newCodeId;
+    Paysage.renameCode = function (oldId, newId) {
+      oldCodeId = oldId;
+      newCodeId = newId;
     };
     Paysage.programmerInit();
     document.getElementById('codeid').oldvalue = 'ancienNom';
     $('#codeid').val('nouveauNom');
     $('#codeid').trigger('change');
     expect(oldCodeId).toBe('ancienNom');
-    expect(goLiveCall).toBe(1);
+    expect(newCodeId).toBe('nouveauNom');
   });
 });

--- a/test/CodeObject.js
+++ b/test/CodeObject.js
@@ -16,7 +16,7 @@ describe('A code object', function () {
     expect(bob.id).to.equal('bob');
   });
 
-  it("'s data contains its id, name and code", function () {
+  it("'s data contains by default its id, name and code", function () {
     expect(bob.getData()).to.deep.equal({
       codeObjectId: 'bob',
       name: 'bob',
@@ -24,14 +24,19 @@ describe('A code object', function () {
     });
   });
 
-  it('can set and get its data', function () {
+  it('can set and get any property', function () {
     bob.setData({ someProperty: 'value' });
 
-    expect(bob.getData()).to.deep.equal({
+    expect(bob.getData().someProperty).to.equal('value');
+  });
+
+  it('can rename a code object', function () {
+    expect(bob.getName()).to.equal('bob');
+    bob.setName('marcel');
+    expect(bob.getName()).to.equal('marcel');
+    expect(bob.getData('name')).to.deep.equal({
       codeObjectId: 'bob',
-      name: 'bob',
-      someProperty: 'value',
-      code: ''
+      name: 'marcel'
     });
   });
 

--- a/test/CodeObject.js
+++ b/test/CodeObject.js
@@ -16,9 +16,10 @@ describe('A code object', function () {
     expect(bob.id).to.equal('bob');
   });
 
-  it("'s data contains its id and code", function () {
+  it("'s data contains its id, name and code", function () {
     expect(bob.getData()).to.deep.equal({
       codeObjectId: 'bob',
+      name: 'bob',
       code: ''
     });
   });
@@ -28,6 +29,7 @@ describe('A code object', function () {
 
     expect(bob.getData()).to.deep.equal({
       codeObjectId: 'bob',
+      name: 'bob',
       someProperty: 'value',
       code: ''
     });

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -20,7 +20,10 @@ describe('A playground', function () {
     playground.getOrCreateCodeObject('bob');
     playground.getOrCreateCodeObject('jack');
     playground.getOrCreateCodeObject('0');
-    expect(playground.population()).to.deep.equal(['bob', 'jack', '0']);
+    expect(playground.population()).to.deep.equal([
+      {id: 'bob', name: 'bob'},
+      {id: 'jack', name: 'jack'},
+      {id: '0', name: '0'}]);
   });
 
   it('can tell if it is empty', function () {
@@ -65,6 +68,7 @@ describe('A playground', function () {
     expect(playground.getData()).to.deep.equal([
       {
         codeObjectId: 'bob',
+        name: 'bob',
         code: 'hello()'
       }
     ]);
@@ -75,6 +79,7 @@ describe('A playground', function () {
     bob.setData({code: 'hello()'});
     expect(playground.getDataFor('bob')).to.deep.equal({
       codeObjectId: 'bob',
+      name: 'bob',
       code: 'hello()'
     });
   });
@@ -82,6 +87,7 @@ describe('A playground', function () {
   it('can create temporary data for a non-existing code object', function () {
     expect(playground.getDataFor('alice')).to.deep.equal({
       codeObjectId: 'alice',
+      name: 'alice',
       code: ''
     });
     expect(playground.contains('alice')).to.be.false;
@@ -93,8 +99,11 @@ describe('A playground', function () {
     playground.getOrCreateCodeObject('lucie');
 
     playground.renameCodeObject('jack', 'jo');
-    expect(playground.population()).to.deep.equal(['bob', 'jo', 'lucie']);
-    expect(playground.getOrCreateCodeObject('jo').id).to.equal('jo');
+    expect(playground.population()).to.deep.equal([
+      {id: 'bob', name: 'bob'},
+      {id: 'jack', name: 'jo'},
+      {id: 'lucie', name: 'lucie'}]);
+    expect(playground.getOrCreateCodeObject('jack').getName()).to.equal('jo');
   });
 });
 

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -86,6 +86,16 @@ describe('A playground', function () {
     });
     expect(playground.contains('alice')).to.be.false;
   });
+
+  it('can rename a code object without changing its place in the list', function () {
+    playground.getOrCreateCodeObject('bob');
+    playground.getOrCreateCodeObject('jack');
+    playground.getOrCreateCodeObject('lucie');
+
+    playground.renameCodeObject('jack', 'jo');
+    expect(playground.population()).to.deep.equal(['bob', 'jo', 'lucie']);
+    expect(playground.getOrCreateCodeObject('jo').id).to.equal('jo');
+  });
 });
 
 describe('Playground notifies', function () {

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -13,17 +13,7 @@ describe('A playground', function () {
   });
 
   it(", when it's new, has no codeObject", function () {
-    expect(playground.population()).to.deep.equal([]);
-  });
-
-  it("can list its codeObject's ids", function () {
-    playground.getOrCreateCodeObject('bob');
-    playground.getOrCreateCodeObject('jack');
-    playground.getOrCreateCodeObject('0');
-    expect(playground.population()).to.deep.equal([
-      {id: 'bob', name: 'bob'},
-      {id: 'jack', name: 'jack'},
-      {id: '0', name: '0'}]);
+    expect(playground.getData()).to.deep.equal([]);
   });
 
   it('can tell if it is empty', function () {
@@ -58,18 +48,39 @@ describe('A playground', function () {
     playground.getOrCreateCodeObject('bob');
     playground.deleteCodeObject('bob');
 
-    expect(playground.population()).to.deep.equal([]);
+    expect(playground.getData()).to.deep.equal([]);
     expect(playground.contains('bob')).to.be.false;
   });
 
   it("'s data contains its code objects", function () {
     var bob = playground.getOrCreateCodeObject('bob');
     bob.setData({code: 'hello()'});
+    playground.getOrCreateCodeObject('alice');
     expect(playground.getData()).to.deep.equal([
       {
         codeObjectId: 'bob',
         name: 'bob',
         code: 'hello()'
+      },
+      {
+        codeObjectId: 'alice',
+        name: 'alice',
+        code: ''
+      }
+    ]);
+  });
+
+  it("can return only one property from it's data", function () {
+    playground.getOrCreateCodeObject('bob');
+    playground.getOrCreateCodeObject('alice');
+    expect(playground.getData('name')).to.deep.equal([
+      {
+        codeObjectId: 'bob',
+        name: 'bob'
+      },
+      {
+        codeObjectId: 'alice',
+        name: 'alice'
       }
     ]);
   });
@@ -99,10 +110,10 @@ describe('A playground', function () {
     playground.getOrCreateCodeObject('lucie');
 
     playground.renameCodeObject('jack', 'jo');
-    expect(playground.population()).to.deep.equal([
-      {id: 'bob', name: 'bob'},
-      {id: 'jack', name: 'jo'},
-      {id: 'lucie', name: 'lucie'}]);
+    expect(playground.getData('name')).to.deep.equal([
+      {codeObjectId: 'bob', name: 'bob'},
+      {codeObjectId: 'jack', name: 'jo'},
+      {codeObjectId: 'lucie', name: 'lucie'}]);
     expect(playground.getOrCreateCodeObject('jack').getName()).to.equal('jo');
   });
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -44,8 +44,8 @@ describe('The Paysage server', function () {
       });
 
       programmer.on('connect', function () {
-        programmer.once('objects list', function (data) {
-          expect(data.objectIdsAndNames).to.deep.equal([]);
+        programmer.once('objects list', function (population) {
+          expect(population.data).to.deep.equal([]);
           halfdone();
         });
       });
@@ -77,8 +77,8 @@ describe('The Paysage server', function () {
     it("sends programmer 'objects list' and renderer 'code update' when programmer updates code", function (done) {
       var halfdone = callWhenCalledTimes(done, 2);
 
-      programmer.on('objects list', function (data) {
-        expect(data.objectIdsAndNames).to.deep.equal([{id: 'bob', name: 'bob'}]);
+      programmer.on('objects list', function (population) {
+        expect(population.data).to.deep.equal([{codeObjectId: 'bob', name: 'bob'}]);
         halfdone();
       });
 
@@ -99,25 +99,25 @@ describe('The Paysage server', function () {
         source: 'dummy source'
       });
 
-      programmer.once('objects list', function (data) {
-        expect(data.objectIdsAndNames).to.deep.equal([
-          {id: 'bill', name: 'bill'}]);
+      programmer.once('objects list', function (population) {
+        expect(population.data).to.deep.equal([
+          {codeObjectId: 'bill', name: 'bill'}]);
 
         programmer.emit('code update', {
           codeObjectId: 'bob',
           source: 'dummy source'
         });
 
-        programmer.once('objects list', function (data) {
-          expect(data.objectIdsAndNames).to.deep.equal([
-            {id: 'bill', name: 'bill'},
-            {id: 'bob', name: 'bob'}]);
+        programmer.once('objects list', function (population) {
+          expect(population.data).to.deep.equal([
+            {codeObjectId: 'bill', name: 'bill'},
+            {codeObjectId: 'bob', name: 'bob'}]);
 
           var halfdone = callWhenCalledTimes(done, 2);
 
-          programmer.on('objects list', function (data) {
-            expect(data.objectIdsAndNames).to.deep.equal([
-              {id: 'bill', name: 'bill'}]);
+          programmer.on('objects list', function (population) {
+            expect(population.data).to.deep.equal([
+              {codeObjectId: 'bill', name: 'bill'}]);
             halfdone();
           });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -45,7 +45,7 @@ describe('The Paysage server', function () {
 
       programmer.on('connect', function () {
         programmer.once('objects list', function (data) {
-          expect(data.objectIds).to.deep.equal([]);
+          expect(data.objectIdsAndNames).to.deep.equal([]);
           halfdone();
         });
       });
@@ -78,7 +78,7 @@ describe('The Paysage server', function () {
       var halfdone = callWhenCalledTimes(done, 2);
 
       programmer.on('objects list', function (data) {
-        expect(data.objectIds).to.deep.equal(['bob']);
+        expect(data.objectIdsAndNames).to.deep.equal([{id: 'bob', name: 'bob'}]);
         halfdone();
       });
 
@@ -100,7 +100,8 @@ describe('The Paysage server', function () {
       });
 
       programmer.once('objects list', function (data) {
-        expect(data.objectIds).to.deep.equal(['bill']);
+        expect(data.objectIdsAndNames).to.deep.equal([
+          {id: 'bill', name: 'bill'}]);
 
         programmer.emit('code update', {
           codeObjectId: 'bob',
@@ -108,12 +109,15 @@ describe('The Paysage server', function () {
         });
 
         programmer.once('objects list', function (data) {
-          expect(data.objectIds).to.deep.equal(['bill', 'bob']);
+          expect(data.objectIdsAndNames).to.deep.equal([
+            {id: 'bill', name: 'bill'},
+            {id: 'bob', name: 'bob'}]);
 
           var halfdone = callWhenCalledTimes(done, 2);
 
           programmer.on('objects list', function (data) {
-            expect(data.objectIds).to.deep.equal(['bill']);
+            expect(data.objectIdsAndNames).to.deep.equal([
+              {id: 'bill', name: 'bill'}]);
             halfdone();
           });
 

--- a/views/programmer.hbs
+++ b/views/programmer.hbs
@@ -16,7 +16,8 @@
   <div class="programmertop programmer-row">
     <input type="hidden" id="playgroundid" value="{{playgroundid}}">
     <input type="hidden" id="clientType" value="programmer">
-    <input type="text" id="codeid"></input>
+    <input type="text" id="codeName"></input>
+    <input type="hidden" id="codeid"></input>
   </div>
   <div class="codewrapper programmer-row">
     <div id="code" rows="20" cols="30"></div>


### PR DESCRIPTION
In order to avoid renaming the id of code object, I introduced "name" property on CodeObject.

This name is not sent to the renderer. The renderer is not impacted by this PR.

Programmers' view know contains two input fields, name and id. Id is hidden.