### PR TITLE
Forces the checkbox of the switch button to be checked on page loading

### DIFF
--- a/public/programmerjs/previewmanagement.js
+++ b/public/programmerjs/previewmanagement.js
@@ -22,5 +22,6 @@
     }
   }
 
+  $('#previewonoff').prop('checked', true);
   $('#previewonoff').on('change', switchframe);
 })();


### PR DESCRIPTION
On firefox, if you reload (simple reload without reloading all the resources)
the page while the switch button is on "preview is off", the switch become
desynchronised from the state of the page. It appears grey and on the left,
while the text says "preview is on" and the preview is effectively on.

To fix this problem this commit forces the state of the hidden checkbox to
match the actual state of the page.