### PR TITLE
Give a name by default (as it was before rename feature)

### DIFF
--- a/CodeObject.js
+++ b/CodeObject.js
@@ -16,6 +16,7 @@ CodeObject.prototype.setData = function (data) {
     if (key !== 'codeObjectId') { that._data[key] = data[key]; }
   });
   this._updated(this);
+  return this;
 };
 
 CodeObject.prototype.getData = function () {

--- a/CodeObject.js
+++ b/CodeObject.js
@@ -18,12 +18,10 @@ CodeObject.prototype.setData = function (data) {
   this._updated(this);
 };
 
-CodeObject.prototype.getData = function (propertyName) {
+CodeObject.prototype.getData = function () {
   var data = { codeObjectId: this.id };
   for (var key of Object.keys(this._data)) {
-    if (!propertyName || propertyName === key) {
-      data[key] = this._data[key];
-    }
+    data[key] = this._data[key];
   }
   return data;
 };

--- a/Playground.js
+++ b/Playground.js
@@ -47,8 +47,7 @@ Playground.prototype.getData = function () {
 Playground.prototype.getDataByName = function (codeObjectName) {
   var codeObject = Array.from(this._codeObjects.values())
     .find((codeObject) => codeObject.getData().name === codeObjectName) ||
-    new CodeObject(codeObjectName);
-  codeObject.setData({ name: codeObjectName });
+    new CodeObject(codeObjectName).setData({ name: codeObjectName });
   return codeObject.getData();
 };
 

--- a/Playground.js
+++ b/Playground.js
@@ -39,9 +39,9 @@ Playground.prototype.contains = function (id) {
   return this._codeObjects.has(id);
 };
 
-Playground.prototype.getData = function (property) {
+Playground.prototype.getData = function () {
   return Array.from(this._codeObjects.values())
-    .map((codeObject) => codeObject.getData(property));
+    .map((codeObject) => codeObject.getData());
 };
 
 Playground.prototype.getDataByName = function (codeObjectName) {

--- a/Playground.js
+++ b/Playground.js
@@ -44,10 +44,11 @@ Playground.prototype.getData = function (property) {
     .map((codeObject) => codeObject.getData(property));
 };
 
-Playground.prototype.getDataFor = function (codeObjectId) {
-  var codeObject =
-    this._codeObjects.get(codeObjectId) ||
-    new CodeObject(codeObjectId);
+Playground.prototype.getDataByName = function (codeObjectName) {
+  var codeObject = Array.from(this._codeObjects.values())
+    .find((codeObject) => codeObject.getData().name === codeObjectName) ||
+    new CodeObject(codeObjectName);
+  codeObject.setData({ name: codeObjectName });
   return codeObject.getData();
 };
 

--- a/Playground.js
+++ b/Playground.js
@@ -44,10 +44,10 @@ Playground.prototype.getData = function () {
     .map((codeObject) => codeObject.getData());
 };
 
-Playground.prototype.getDataByName = function (codeObjectName) {
-  var codeObject = Array.from(this._codeObjects.values())
-    .find((codeObject) => codeObject.getData().name === codeObjectName) ||
-    new CodeObject(codeObjectName).setData({ name: codeObjectName });
+Playground.prototype.getDataFor = function (codeObjectId) {
+  var codeObject =
+    this._codeObjects.get(codeObjectId) ||
+    new CodeObject(codeObjectId);
   return codeObject.getData();
 };
 

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ module.exports = function (maybeWorld) {
     }
 
     function sendListOfAllObjects () {
-      socket.emit('objects list', {data: playground.getData('name')});
+      socket.emit('objects list', {data: playground.getData()});
     }
 
     function programmerUp () {

--- a/app.js
+++ b/app.js
@@ -99,9 +99,8 @@ module.exports = function (maybeWorld) {
     });
 
     socket.on('request code', function (data) {
-      debug(data.codeObjectId + ' for ' + playground.id + ' programmer');
-
-      socket.emit('source code', playground.getDataFor(data.codeObjectId));
+      debug(data.codeObjectName + ' for ' + playground.id + ' programmer');
+      socket.emit('source code', playground.getDataByName(data.codeObjectName));
     });
 
     function codeObjectUpdated (codeObject) {

--- a/app.js
+++ b/app.js
@@ -99,8 +99,8 @@ module.exports = function (maybeWorld) {
     });
 
     socket.on('request code', function (data) {
-      debug(data.codeObjectName + ' for ' + playground.id + ' programmer');
-      socket.emit('source code', playground.getDataByName(data.codeObjectName));
+      debug(data.codeObjectId + ' for ' + playground.id + ' programmer');
+      socket.emit('source code', playground.getDataFor(data.codeObjectId));
     });
 
     function codeObjectUpdated (codeObject) {

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "tests"
   ],
   "dependencies": {
-    "chance": "~0.8.0",
+    "chance": "~1.0.16",
     "Processing.js": "~1.6.6",
     "jquery": "~2.2.4",
     "jquery-ui": "~1.12",

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -8,15 +8,17 @@ var Paysage = window.Paysage || {};
 
   Paysage.setCodeId = function (codeId) {
     $('#codeid').val(codeId);
-    window.location.hash = codeId;
   };
 
   Paysage.setCodeName = function (codeName) {
     $('#codeName').val(codeName);
+    window.location.hash = codeName;
   };
 
   Paysage.createCodeId = function () {
-    Paysage.setCodeId(window.chance.word());
+    var name = window.chance.word();
+    Paysage.setCodeId(name);
+    Paysage.setCodeName(name);
   };
 
   Paysage.getCode = function () {
@@ -35,10 +37,10 @@ var Paysage = window.Paysage || {};
         event.preventDefault();
         deleteCodeCB(co.codeObjectId);
       });
-      var $openLink = $("<a href='#" + co.codeObjectId + "'>").text(co.name);
+      var $openLink = $("<a href='#" + co.name + "'>").text(co.name);
       $openLink.click(function (event) {
         event.preventDefault();
-        Paysage.requestCode(co.codeObjectId);
+        Paysage.requestCode(co.name);
       });
       return $('<li>').append($openLink).append($deleteLink);
     }));
@@ -103,11 +105,6 @@ var Paysage = window.Paysage || {};
     Paysage.createCodeId();
     $.get($(this).data('src'), function (data) {
       Paysage.setCode(data);
-      setTimeout(function () {
-        var codeNameField = document.getElementById('codeName');
-        codeNameField.value = '';
-        codeNameField.focus();
-      }, 10);
     });
     $('#new-object-dialog').dialog('close');
   });

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -11,24 +11,21 @@ var Paysage = window.Paysage || {};
   // - Paysage.getCompleteCodeObject()
 
   function goLive () {
-    Paysage.getCompleteCodeObject(Paysage.emitCodeUpdate);
-    window.location.hash = $('#codeName').val();
+    Paysage.emitCodeUpdate(Paysage.getCompleteCodeObject());
   }
-  $('#go-live').on('click', goLive);
 
   Paysage.setCodeId = function (codeId) {
     $('#codeid').val(codeId);
+    window.location.hash = codeId;
   };
 
   Paysage.setCodeName = function (codeName) {
     $('#codeName').val(codeName);
-    window.location.hash = codeName;
   };
 
   Paysage.createCodeId = function () {
-    var name = window.chance.word();
-    Paysage.setCodeId(name);
-    Paysage.setCodeName(name);
+    Paysage.setCodeId(window.chance.word({syllables: 3}));
+    Paysage.setCodeName(window.chance.animal());
   };
 
   Paysage.getCode = function () {
@@ -47,10 +44,10 @@ var Paysage = window.Paysage || {};
         event.preventDefault();
         deleteCodeCB(co.codeObjectId);
       });
-      var $openLink = $("<a href='#" + co.name + "'>").text(co.name);
+      var $openLink = $("<a href='#" + co.codeObjectId + "'>").text(co.name);
       $openLink.click(function (event) {
         event.preventDefault();
-        Paysage.requestCode(co.name);
+        Paysage.requestCode(co.codeObjectId);
       });
       return $('<li>').append($openLink).append($deleteLink);
     }));
@@ -74,6 +71,8 @@ var Paysage = window.Paysage || {};
       Paysage.startNewObject();
       Paysage.createCodeId();
     }
+
+    $('#go-live').on('click', goLive);
 
     setupDragAndDropListeners();
     $('#start-new-code').on('click', Paysage.startNewObject);

--- a/public/programmerjs/editingcode.js
+++ b/public/programmerjs/editingcode.js
@@ -4,7 +4,17 @@ var Paysage = window.Paysage || {};
 (function () {
   'use strict';
 
-  // Requires a receptiontransmission script defining Paysage.requestCode()
+  // Requires a receptiontransmission script defining
+  // - Paysage.requestCode()
+  // - Paysage.emitCodeUpdate()
+  // Requires a sourcebuilder script defining
+  // - Paysage.getCompleteCodeObject()
+
+  function goLive () {
+    Paysage.getCompleteCodeObject(Paysage.emitCodeUpdate);
+    window.location.hash = $('#codeName').val();
+  }
+  $('#go-live').on('click', goLive);
 
   Paysage.setCodeId = function (codeId) {
     $('#codeid').val(codeId);
@@ -77,7 +87,7 @@ var Paysage = window.Paysage || {};
       editor.commands.addCommand({
         name: 'go-liveShortcuts',
         bindKey: {win: 'Ctrl-Enter', mac: 'Command-Enter'},
-        exec: Paysage.goLive
+        exec: goLive
       });
       editor.$blockScrolling = Infinity; // to avoid the warning about deprecated scrolling https://github.com/ajaxorg/ace/issues/2499
 

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -3,16 +3,6 @@ var Paysage = window.Paysage || {};
 (function () {
   'use strict';
 
-  // Requires a sourcebuilder script defining Paysage.getCompleteCodeObject()
-  // Requires a editingcode script defining Paysage.setCodeId(),
-  // Paysage.setObjectList(data), Paysage.setCodeName() and Paysage.setCode()
-
-  Paysage.requestCode = function (codeObjectName) {
-    io.emit('request code', {
-      codeObjectName: codeObjectName
-    });
-  };
-
   var playgroundid = document.getElementById('playgroundid').value;
   var clientType = document.getElementById('clientType').value;
 
@@ -21,15 +11,18 @@ var Paysage = window.Paysage || {};
     client: clientType
   }}).connect();
 
-  Paysage.goLive = function () {
-    function emitData (data) {
-      console.log(data);
-      io.emit('code update', data);
-      window.location.hash = data.name;
-    }
-    Paysage.getCompleteCodeObject(emitData);
+  // Transmission
+
+  Paysage.requestCode = function (codeObjectName) {
+    io.emit('request code', {
+      codeObjectName: codeObjectName
+    });
   };
-  document.getElementById('go-live').addEventListener('click', Paysage.goLive);
+
+  Paysage.emitCodeUpdate = function (data) {
+    console.log(data);
+    io.emit('code update', data);
+  };
 
   Paysage.deleteCode = function (codeObjectId) {
     var data = {
@@ -37,6 +30,11 @@ var Paysage = window.Paysage || {};
     };
     io.emit('code delete', data);
   };
+
+  // Reception
+
+  // Requires a editingcode script defining Paysage.setCodeId(),
+  // Paysage.setObjectList(data), Paysage.setCodeName() and Paysage.setCode()
 
   io.on('objects list', function (population) {
     Paysage.setObjectList(population, Paysage.deleteCode);

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -7,11 +7,10 @@ var Paysage = window.Paysage || {};
   // Requires a editingcode script defining Paysage.setCodeId(),
   // Paysage.setObjectList(data), Paysage.setCodeName() and Paysage.setCode()
 
-  Paysage.requestCode = function (codeObjectId) {
-    var data = {
-      codeObjectId: codeObjectId
-    };
-    io.emit('request code', data);
+  Paysage.requestCode = function (codeObjectName) {
+    io.emit('request code', {
+      codeObjectName: codeObjectName
+    });
   };
 
   var playgroundid = document.getElementById('playgroundid').value;
@@ -26,6 +25,7 @@ var Paysage = window.Paysage || {};
     function emitData (data) {
       console.log(data);
       io.emit('code update', data);
+      window.location.hash = data.name;
     }
     Paysage.getCompleteCodeObject(emitData);
   };

--- a/public/programmerjs/receptiontransmission.js
+++ b/public/programmerjs/receptiontransmission.js
@@ -13,9 +13,9 @@ var Paysage = window.Paysage || {};
 
   // Transmission
 
-  Paysage.requestCode = function (codeObjectName) {
+  Paysage.requestCode = function (codeObjectId) {
     io.emit('request code', {
-      codeObjectName: codeObjectName
+      codeObjectId: codeObjectId
     });
   };
 

--- a/public/programmerjs/sourcebuilder.js
+++ b/public/programmerjs/sourcebuilder.js
@@ -10,7 +10,7 @@
 
 var Paysage = window.Paysage || {};
 
-Paysage.getCompleteCodeObject = function (callback) {
+Paysage.getCompleteCodeObject = function () {
   var codeObjectId = document.getElementById('codeid').value || document.getElementById('codeid').textContent;
   var codeObjectName = document.getElementById('codeName').value;
   var mediatype = 'text/processing';
@@ -22,5 +22,5 @@ Paysage.getCompleteCodeObject = function (callback) {
     mediatype: mediatype,
     code: code
   };
-  callback(data);
+  return data;
 };

--- a/public/workshopfiles/creaturecommonfiles/creaturecodeinitialization.js
+++ b/public/workshopfiles/creaturecommonfiles/creaturecodeinitialization.js
@@ -4,6 +4,11 @@ var Paysage = window.Paysage || {};
 // thanks https://gist.github.com/jlong/2428561
 var creaturename = window.location.hash.slice(1);
 
+function goLive () {
+  Paysage.getCompleteCodeObject(Paysage.emitCodeUpdate);
+}
+$('#go-live').on('click', goLive);
+
 Paysage.setCodeId = function (codeId) {
   window.location.hash = codeId;
   $('#codeid').html(creaturename);

--- a/public/workshopfiles/creaturecommonfiles/creaturecodeinitialization.js
+++ b/public/workshopfiles/creaturecommonfiles/creaturecodeinitialization.js
@@ -5,7 +5,7 @@ var Paysage = window.Paysage || {};
 var creaturename = window.location.hash.slice(1);
 
 function goLive () {
-  Paysage.getCompleteCodeObject(Paysage.emitCodeUpdate);
+  Paysage.getCompleteCodeObjectAsync(Paysage.emitCodeUpdate);
 }
 $('#go-live').on('click', goLive);
 

--- a/public/workshopfiles/creaturecommonfiles/creaturesourcebuilder.js
+++ b/public/workshopfiles/creaturecommonfiles/creaturesourcebuilder.js
@@ -9,7 +9,7 @@ var Paysage = window.Paysage || {};
 
 // the sourcebuilder only concern is to build and give a code object ready to be sent to the paysage server
 
-Paysage.getCompleteCodeObject = function (callback) {
+Paysage.getCompleteCodeObjectAsync = function (callback) {
   var playgroundid = document.getElementById('playgroundid').value;
   var codeObjectId = document.getElementById('codeid').value || document.getElementById('codeid').textContent;
   var mediatype = 'text/processing';

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -26,30 +26,46 @@ describe('The Paysage programmer', function () {
     expect($('#new-object-dialog').parent().css('display')).toBe('block');
   });
 
-  it('request the code when codeName is present on the url', function () {
-    window.location.hash = 'myName';
+  it('request the code when codeId is present on the url', function () {
+    window.location.hash = 'toto';
 
-    var requestedCodeName;
-    Paysage.requestCode = function (codeObjectName) {
-      requestedCodeName = codeObjectName;
+    var requestedCodeId;
+    Paysage.requestCode = function (codeObjectId) {
+      requestedCodeId = codeObjectId;
     };
 
     Paysage.programmerInit();
 
-    expect(requestedCodeName).toBe('myName');
+    expect(requestedCodeId).toBe('toto');
     expect($('#new-object-dialog').css('display')).toBe('none');
+  });
+
+  it('emit code object when clicking the go-live button', function () {
+    var completeCodeObjectData = {};
+    var dataToEmit = null;
+    Paysage.emitCodeUpdate = function (data) {
+      dataToEmit = data;
+    };
+    Paysage.getCompleteCodeObject = function () {
+      return completeCodeObjectData;
+    };
+    Paysage.programmerInit();
+
+    $('#go-live').trigger('click');
+
+    expect(dataToEmit).toBe(completeCodeObjectData);
   });
 
   it('can show the object list', function () {
     Paysage.setObjectList({
       data: [
-        {codeObjectId: 'object1', name: 'name1'},
+        {codeObjectId: 'object1', name: 'name 1'},
         {codeObjectId: 'object2', name: 'name2'}
       ]
     });
     var $list = $('#objects').html();
-    expect($list).toContain('<li><a href="#name1">name1</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
-    expect($list).toContain('<li><a href="#name2">name2</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
+    expect($list).toContain('<li><a href="#object1">name 1</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
+    expect($list).toContain('<li><a href="#object2">name2</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
   });
 
   it('list objects in reverse order', function () {

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -7,6 +7,7 @@ describe('The Paysage programmer', function () {
       '<div><input id="codeName"></div>' +
       '<div id="new-object-dialog" style="display:none;"></div>' +
       '<div id="objects"></div>' +
+      '<button id="go-live"></button>' +
       '</div>'
     );
     window.location.hash = '';

--- a/spec/public/programmer_spec.js
+++ b/spec/public/programmer_spec.js
@@ -25,17 +25,17 @@ describe('The Paysage programmer', function () {
     expect($('#new-object-dialog').parent().css('display')).toBe('block');
   });
 
-  it('request the code when codeId is present on the url', function () {
-    window.location.hash = 'toto';
+  it('request the code when codeName is present on the url', function () {
+    window.location.hash = 'myName';
 
-    var requestedCodeId;
-    Paysage.requestCode = function (codeObjectId) {
-      requestedCodeId = codeObjectId;
+    var requestedCodeName;
+    Paysage.requestCode = function (codeObjectName) {
+      requestedCodeName = codeObjectName;
     };
 
     Paysage.programmerInit();
 
-    expect(requestedCodeId).toBe('toto');
+    expect(requestedCodeName).toBe('myName');
     expect($('#new-object-dialog').css('display')).toBe('none');
   });
 
@@ -47,8 +47,8 @@ describe('The Paysage programmer', function () {
       ]
     });
     var $list = $('#objects').html();
-    expect($list).toContain('<li><a href="#object1">name1</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
-    expect($list).toContain('<li><a href="#object2">name2</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
+    expect($list).toContain('<li><a href="#name1">name1</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
+    expect($list).toContain('<li><a href="#name2">name2</a><a class="glyphicon glyphicon-remove-circle" href="#"></a></li>');
   });
 
   it('list objects in reverse order', function () {

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -83,21 +83,22 @@ describe('A playground', function () {
     ]);
   });
 
-  it('can return data for an existing code object', function () {
-    var bob = playground.getOrCreateCodeObject('bob');
-    bob.setData({code: 'hello()'});
-    expect(playground.getDataFor('bob')).to.deep.equal({
+  it('can return data by name for an existing code object', function () {
+    playground.getOrCreateCodeObject('bob')
+      .setData({name: 'bobName', code: 'any code'});
+    expect(playground.getDataByName('bobName')).to.deep.equal({
       codeObjectId: 'bob',
-      code: 'hello()'
+      name: 'bobName',
+      code: 'any code'
     });
   });
 
-  it('can create temporary data for a non-existing code object', function () {
-    expect(playground.getDataFor('alice')).to.deep.equal({
-      codeObjectId: 'alice',
+  it('can return data by name for a non-existing code object', function () {
+    expect(playground.getDataByName('bob')).to.deep.equal({
+      codeObjectId: 'bob',
+      name: 'bob',
       code: ''
     });
-    expect(playground.contains('alice')).to.be.false;
   });
 });
 

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -70,22 +70,21 @@ describe('A playground', function () {
     ]);
   });
 
-  it('can return data by name for an existing code object', function () {
-    playground.getOrCreateCodeObject('bob')
-      .setData({name: 'bobName', code: 'any code'});
-    expect(playground.getDataByName('bobName')).to.deep.equal({
+  it('can return data for an existing code object', function () {
+    var bob = playground.getOrCreateCodeObject('bob');
+    bob.setData({code: 'hello()'});
+    expect(playground.getDataFor('bob')).to.deep.equal({
       codeObjectId: 'bob',
-      name: 'bobName',
-      code: 'any code'
+      code: 'hello()'
     });
   });
 
-  it('can return data by name for a non-existing code object', function () {
-    expect(playground.getDataByName('bob')).to.deep.equal({
-      codeObjectId: 'bob',
-      name: 'bob',
+  it('can create temporary data for a non-existing code object', function () {
+    expect(playground.getDataFor('alice')).to.deep.equal({
+      codeObjectId: 'alice',
       code: ''
     });
+    expect(playground.contains('alice')).to.be.false;
   });
 });
 

--- a/test/Playground.js
+++ b/test/Playground.js
@@ -53,9 +53,10 @@ describe('A playground', function () {
   });
 
   it("'s data contains its code objects", function () {
-    var bob = playground.getOrCreateCodeObject('bob');
-    bob.setData({code: 'hello()'});
-    playground.getOrCreateCodeObject('alice');
+    playground.getOrCreateCodeObject('bob')
+      .setData({code: 'hello()'});
+    playground.getOrCreateCodeObject('alice')
+      .setData({name: 'AliceName'});
     expect(playground.getData()).to.deep.equal([
       {
         codeObjectId: 'bob',
@@ -63,22 +64,8 @@ describe('A playground', function () {
       },
       {
         codeObjectId: 'alice',
+        name: 'AliceName',
         code: ''
-      }
-    ]);
-  });
-
-  it("can return a single property from it's data", function () {
-    playground.getOrCreateCodeObject('id1').setData({name: 'bob', code: 'any code'});
-    playground.getOrCreateCodeObject('id2').setData({name: 'alice', code: 'any code'});
-    expect(playground.getData('name')).to.deep.equal([
-      {
-        codeObjectId: 'id1',
-        name: 'bob'
-      },
-      {
-        codeObjectId: 'id2',
-        name: 'alice'
       }
     ]);
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -78,7 +78,8 @@ describe('The Paysage server', function () {
       var halfdone = callWhenCalledTimes(done, 2);
 
       programmer.on('objects list', function (population) {
-        expect(population.data).to.deep.equal([{codeObjectId: 'id1', name: 'boby'}]);
+        expect(population.data.length).to.equal(1);
+        expect(population.data[0].codeObjectId).to.equal('id1');
         halfdone();
       });
 
@@ -102,8 +103,8 @@ describe('The Paysage server', function () {
       });
 
       programmer.once('objects list', function (population) {
-        expect(population.data).to.deep.equal([
-          {codeObjectId: 'id1', name: 'bill'}]);
+        expect(population.data.length).to.equal(1);
+        expect(population.data[0].codeObjectId).to.equal('id1');
 
         programmer.emit('code update', {
           codeObjectId: 'id2',
@@ -112,15 +113,15 @@ describe('The Paysage server', function () {
         });
 
         programmer.once('objects list', function (population) {
-          expect(population.data).to.deep.equal([
-            {codeObjectId: 'id1', name: 'bill'},
-            {codeObjectId: 'id2', name: 'bob'}]);
+          expect(population.data.length).to.equal(2);
+          expect(population.data[0].codeObjectId).to.equal('id1');
+          expect(population.data[1].codeObjectId).to.equal('id2');
 
           var halfdone = callWhenCalledTimes(done, 2);
 
           programmer.on('objects list', function (population) {
-            expect(population.data).to.deep.equal([
-              {codeObjectId: 'id1', name: 'bill'}]);
+            expect(population.data.length).to.equal(1);
+            expect(population.data[0].codeObjectId).to.equal('id1');
             halfdone();
           });
 


### PR DESCRIPTION
Make the application behave like it was before the introduction of the rename feature, that is : 

- a name is chosen by default when you add a new creature
- you don't see any technical id. The URL is holding the name of the creature.

But you still can rename a creature