### PR TITLE
Use the url hash of the renderer to manage code objects visibility

### DIFF
--- a/public/paysagerenderer/main.js
+++ b/public/paysagerenderer/main.js
@@ -4,11 +4,12 @@ var Paysage = window.Paysage || {};
 (function () {
   'use strict';
 
-  var canvas, layers, container, playgroundId;
+  var canvas, layers, codes, container, playgroundId;
 
   Paysage.rendererInit = function () {
     canvas = Object.create(null);
     layers = Object.create(null);
+    codes = Object.create(null);
 
     container = document.getElementById('container');
     playgroundId = container.getAttribute('data-playgroundid');
@@ -42,11 +43,36 @@ var Paysage = window.Paysage || {};
     });
 
     installResizeHandler();
+
+    var urlHash = '';
+    setInterval(function () {
+      var newHash = window.location.hash;
+      if (urlHash === newHash) {
+        return;
+      }
+      urlHash = newHash;
+
+      Paysage.showCodeObjects(
+        Object.keys(canvas),
+        Paysage.readIdsFromUrlHash(urlHash),
+        function (id) {
+          console.log('show: ' + id);
+          deleteLayer(id);
+          canvas[id].style.display = '';
+          layers[id] = createLayer(canvas[id], codes[id], id);
+        },
+        function (id) {
+          console.log('hide: ' + id);
+          deleteLayer(id);
+          canvas[id].style.display = 'none';
+        });
+    }, 100);
   };
 
   function clearLayersAndCanvas () {
     Object.keys(layers).forEach(deleteLayer);
     Object.keys(canvas).forEach(deleteCanvas);
+    codes = Object.create(null);
   }
 
   function resizeToWindow (layer) {
@@ -88,8 +114,13 @@ var Paysage = window.Paysage || {};
   }
 
   function createCanvas (id) {
-    canvas[id] = document.createElement('canvas');
-    container.appendChild(canvas[id]);
+    if (!canvas[id]) {
+      canvas[id] = document.createElement('canvas');
+      container.appendChild(canvas[id]);
+      console.log('canvas created for ' + id);
+    } else {
+      console.log('canvas reused for ' + id);
+    }
   }
 
   function deleteCanvas (id) {
@@ -109,13 +140,9 @@ var Paysage = window.Paysage || {};
   function updateObject (id, code) {
     try {
       deleteLayer(id);
-      if (!canvas[id]) {
-        createCanvas(id);
-        console.log('canvas created for ' + id);
-      } else {
-        console.log('canvas reused for ' + id);
-      }
+      createCanvas(id);
       layers[id] = createLayer(canvas[id], code, id);
+      codes[id] = code;
     } catch (e) {
       console.error('Error in code object "' + id + '". Code not rendered.', e);
     }

--- a/public/paysagerenderer/visibility_management.js
+++ b/public/paysagerenderer/visibility_management.js
@@ -1,0 +1,22 @@
+/* eslint no-eval: "off" */
+var Paysage = window.Paysage || {};
+
+const ONLY_COMMAND = '#only=';
+
+Paysage.readIdsFromUrlHash = function (urlHash) {
+  if (urlHash.startsWith(ONLY_COMMAND)) {
+    var idsList = urlHash.substring(ONLY_COMMAND.length);
+    return idsList === '' ? [] : idsList.split(',');
+  }
+  return undefined;
+};
+
+Paysage.showCodeObjects = function (allIds, idsToShow, show, hide) {
+  allIds.forEach(function (id) {
+    if (!idsToShow || idsToShow.includes(id)) {
+      show(id);
+    } else {
+      hide(id);
+    }
+  });
+};

--- a/public/paysagerenderer/visibility_management.js
+++ b/public/paysagerenderer/visibility_management.js
@@ -3,20 +3,26 @@ var Paysage = window.Paysage || {};
 
 const ONLY_COMMAND = '#only=';
 
+Paysage.idsToShow = undefined;
+
 Paysage.readIdsFromUrlHash = function (urlHash) {
+  Paysage.idsToShow = undefined;
   if (urlHash.startsWith(ONLY_COMMAND)) {
     var idsList = urlHash.substring(ONLY_COMMAND.length);
-    return idsList === '' ? [] : idsList.split(',');
+    Paysage.idsToShow = idsList === '' ? [] : idsList.split(',');
   }
-  return undefined;
 };
 
-Paysage.showCodeObjects = function (allIds, idsToShow, show, hide) {
+Paysage.filterCodeObjects = function (allIds, show, hide) {
   allIds.forEach(function (id) {
-    if (!idsToShow || idsToShow.includes(id)) {
+    if (Paysage.isCodeObjectVisible(id)) {
       show(id);
     } else {
       hide(id);
     }
   });
+};
+
+Paysage.isCodeObjectVisible = function (id) {
+  return !Paysage.idsToShow || Paysage.idsToShow.includes(id);
 };

--- a/public/programmerjs/previewmanagement.js
+++ b/public/programmerjs/previewmanagement.js
@@ -3,20 +3,18 @@
 (function () {
   'use strict';
 
-  var frozenpreview = null;
+  var previewIsOn = true;
 
   function switchframe (event) {
     event.preventDefault();
-    if (frozenpreview) {
-      frozenpreview.appendTo('#viewercontainer');
-      frozenpreview = null;
-      $('#viewercontainer').show();
+    if (previewIsOn) {
+      previewIsOn = false;
       $('#previewisoff').hide();
       $('#previewison').show();
+      $('#viewerframe').attr('src', '/playground/' + $('#playgroundid').val() + '#only=');
     } else {
-      $('#viewercontainer').hide(1, function () {
-        frozenpreview = $('#viewerframe').detach();
-      });
+      previewIsOn = true;
+      $('#viewerframe').attr('src', '/playground/' + $('#playgroundid').val() + '#');
       $('#previewison').hide();
       $('#previewisoff').show();
     }

--- a/spec/public/paysagerenderer/visibility_management_spec.js
+++ b/spec/public/paysagerenderer/visibility_management_spec.js
@@ -2,11 +2,20 @@
 /* global Paysage */
 describe('The Paysage renderer visibility management', function () {
   it('can parse Url hash for code objects ids to display', function () {
-    expect(Paysage.readIdsFromUrlHash('')).toEqual(undefined);
-    expect(Paysage.readIdsFromUrlHash('#')).toEqual(undefined);
-    expect(Paysage.readIdsFromUrlHash('#only=toto')).toEqual(['toto']);
-    expect(Paysage.readIdsFromUrlHash('#only=toto,titi')).toEqual(['toto', 'titi']);
-    expect(Paysage.readIdsFromUrlHash('#only=')).toEqual([]);
+    Paysage.readIdsFromUrlHash('');
+    expect(Paysage.idsToShow).toEqual(undefined);
+
+    Paysage.readIdsFromUrlHash('#');
+    expect(Paysage.idsToShow).toEqual(undefined);
+
+    Paysage.readIdsFromUrlHash('#only=toto');
+    expect(Paysage.idsToShow).toEqual(['toto']);
+
+    Paysage.readIdsFromUrlHash('#only=toto,titi');
+    expect(Paysage.idsToShow).toEqual(['toto', 'titi']);
+
+    Paysage.readIdsFromUrlHash('#only=');
+    expect(Paysage.idsToShow).toEqual([]);
   });
 
   describe('has code object filtering', function () {
@@ -27,14 +36,16 @@ describe('The Paysage renderer visibility management', function () {
     });
 
     it('that show all code objects when no id is given', function () {
-      Paysage.showCodeObjects(['toto', 'titi'], undefined, show, hide);
+      Paysage.idsToShow = undefined;
+      Paysage.filterCodeObjects(['toto', 'titi'], show, hide);
 
       expect(shownIds).toEqual(['toto', 'titi']);
       expect(hiddenIds).toEqual([]);
     });
 
     it('that show only requeted code objects', function () {
-      Paysage.showCodeObjects(['toto', 'titi'], ['toto'], show, hide);
+      Paysage.idsToShow = ['toto'];
+      Paysage.filterCodeObjects(['toto', 'titi'], show, hide);
 
       expect(shownIds).toEqual(['toto']);
       expect(hiddenIds).toEqual(['titi']);

--- a/spec/public/paysagerenderer/visibility_management_spec.js
+++ b/spec/public/paysagerenderer/visibility_management_spec.js
@@ -1,0 +1,43 @@
+/* global describe, beforeEach, it, expect */
+/* global Paysage */
+describe('The Paysage renderer visibility management', function () {
+  it('can parse Url hash for code objects ids to display', function () {
+    expect(Paysage.readIdsFromUrlHash('')).toEqual(undefined);
+    expect(Paysage.readIdsFromUrlHash('#')).toEqual(undefined);
+    expect(Paysage.readIdsFromUrlHash('#only=toto')).toEqual(['toto']);
+    expect(Paysage.readIdsFromUrlHash('#only=toto,titi')).toEqual(['toto', 'titi']);
+    expect(Paysage.readIdsFromUrlHash('#only=')).toEqual([]);
+  });
+
+  describe('has code object filtering', function () {
+    var shownIds;
+    var hiddenIds;
+
+    var show = function (id) {
+      shownIds.push(id);
+    };
+
+    var hide = function (id) {
+      hiddenIds.push(id);
+    };
+
+    beforeEach(function () {
+      shownIds = [];
+      hiddenIds = [];
+    });
+
+    it('that show all code objects when no id is given', function () {
+      Paysage.showCodeObjects(['toto', 'titi'], undefined, show, hide);
+
+      expect(shownIds).toEqual(['toto', 'titi']);
+      expect(hiddenIds).toEqual([]);
+    });
+
+    it('that show only requeted code objects', function () {
+      Paysage.showCodeObjects(['toto', 'titi'], ['toto'], show, hide);
+
+      expect(shownIds).toEqual(['toto']);
+      expect(hiddenIds).toEqual(['titi']);
+    });
+  });
+});

--- a/testem.yml
+++ b/testem.yml
@@ -6,7 +6,8 @@ src_files:
   - "public/bower_components/eventEmitter/EventEmitter.js"
   - "public/bower_components/Processing.js/processing.js"
   - "public/bower_components/jasmine-jquery/lib/jasmine-jquery.js"
-  - "public/paysagerenderer.js"
+  - "public/paysagerenderer/main.js"
+  - "public/paysagerenderer/visibility_management.js"
   - "public/programmerjs/editingcode.js"
   - "spec/public/**/*.js"
 browser_args:

--- a/views/playground.hbs
+++ b/views/playground.hbs
@@ -16,7 +16,8 @@
 
     <script src="/bower_components/Processing.js/processing.js"></script>
     <script src="{{socketioClient}}"></script>
-    <script src="/paysagerenderer.js"></script>
+    <script src="/paysagerenderer/main.js"></script>
+    <script src="/paysagerenderer/visibility_management.js"></script>
     <script>
       Paysage.rendererInit();
     </script>


### PR DESCRIPTION
All this started with the issue #113, about helping users to find their code object among others in the programmer view.

In the process of introducing a "solo" mode we identified the need of an interface between the programmer view and the renderer.

This PR is about implementing this interface using the URL of the renderer.
Here are the supported options, as an example with a playground named pg:

`https://paysage.xyz/playground/pg#only=myCodeId` to show only one code,
`https://paysage.xyz/playground/pg#` to show all codes,
`https://paysage.xyz/playground/pg#only=` to show none.
This PR is also providing a mean to show a specific list of codeIds what is not necessary for implementing the solo mode, but might be useful for more advanced behaviours:
`https://paysage.xyz/playground/pg#only=codeId1,codeId2`

This last point is open to comment (among any other review comments). Do we want to keep this ?